### PR TITLE
Make library importable by CMake using find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,7 @@ include(GNUInstallDirs)
 
 # creates a library GSL which is an interface (header files only)
 # Target must be renamed to avoid conflics with GNU Scientific Library
-add_library(Microsoft.GSL INTERFACE)
-add_library(GSL ALIAS Microsoft.GSL)
+add_library(GSL INTERFACE)
 
 # determine whether this is a standalone project or included by other projects
 set(GSL_STANDALONE_PROJECT OFF)
@@ -26,7 +25,7 @@ if (CMAKE_VERSION VERSION_LESS 3.7.9)
         include(CheckCXXCompilerFlag)
         CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
         if(COMPILER_SUPPORTS_CXX14)
-            target_compile_options(Microsoft.GSL INTERFACE "-std=c++14")
+            target_compile_options(GSL INTERFACE "-std=c++14")
         else()
             message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
         endif()
@@ -34,13 +33,13 @@ if (CMAKE_VERSION VERSION_LESS 3.7.9)
     endif()
 else ()
     # set the GSL library to be compiled only with c++14
-    target_compile_features(Microsoft.GSL INTERFACE cxx_std_14)
+    target_compile_features(GSL INTERFACE cxx_std_14)
     # on *nix systems force the use of -std=c++XX instead of -std=gnu++XX (default)
     set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 # add definitions to the library and targets that consume it
-target_compile_definitions(Microsoft.GSL INTERFACE
+target_compile_definitions(GSL INTERFACE
     $<$<CXX_COMPILER_ID:MSVC>:
         # remove unnecessary warnings about unchecked iterators
         _SCL_SECURE_NO_WARNINGS
@@ -48,10 +47,8 @@ target_compile_definitions(Microsoft.GSL INTERFACE
 )
 
 # add include folders to the library and targets that consume it
-target_include_directories(Microsoft.GSL INTERFACE
-    $<BUILD_INTERFACE:
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    >
+target_include_directories(GSL INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -63,12 +60,12 @@ endif()
 
 # add natvis file to the library so it will automatically be loaded into Visual Studio
 if(VS_ADD_NATIVE_VISUALIZERS)
-  target_sources(Microsoft.GSL INTERFACE
+  target_sources(GSL INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/GSL.natvis
     )
 endif()
 
-install(TARGETS Microsoft.GSL EXPORT Microsoft.GSLConfig
+install(TARGETS GSL EXPORT Microsoft.GSLConfig
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -78,8 +75,8 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 # Make library importable by other projects
-install(EXPORT Microsoft.GSLConfig DESTINATION share/Microsoft.GSL/cmake)
-export(TARGETS Microsoft.GSL FILE Microsoft.GSLConfig.cmake)
+install(EXPORT Microsoft.GSLConfig NAMESPACE Microsoft.GSL:: DESTINATION share/Microsoft.GSL/cmake)
+export(TARGETS GSL NAMESPACE Microsoft.GSL:: FILE Microsoft.GSLConfig.cmake)
 
 
 option(GSL_TEST "Generate tests." ${GSL_STANDALONE_PROJECT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 # Make library importable by other projects
-install(EXPORT Microsoft.GSLConfig DESTINATION share/GSL/cmake)
+install(EXPORT Microsoft.GSLConfig DESTINATION share/Microsoft.GSL/cmake)
 export(TARGETS Microsoft.GSL FILE Microsoft.GSLConfig.cmake)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(GSL CXX)
 include(ExternalProject)
 find_package(Git)
 
+# Use GNUInstallDirs to provide the right locations on all platforms
+include(GNUInstallDirs)
+
 # creates a library GSL which is an interface (header files only)
 add_library(GSL INTERFACE)
 
@@ -47,6 +50,7 @@ target_include_directories(GSL INTERFACE
     $<BUILD_INTERFACE:
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     >
+    $<INSTALL_INTERFACE:include>
 )
 
 if (MSVC_IDE)
@@ -62,10 +66,18 @@ if(VS_ADD_NATIVE_VISUALIZERS)
     )
 endif()
 
+install(TARGETS GSL EXPORT GSLConfig
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 install(
     DIRECTORY include/gsl
-    DESTINATION include
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+# Make library importable by other projects
+install(EXPORT GSLConfig DESTINATION share/GSL/cmake)
+export(TARGETS GSL FILE GSLConfig.cmake)
 
 option(GSL_TEST "Generate tests." ${GSL_STANDALONE_PROJECT})
 if (GSL_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 # add natvis file to the library so it will automatically be loaded into Visual Studio
 if(VS_ADD_NATIVE_VISUALIZERS)
   target_sources(GSL INTERFACE
-        ${CMAKE_CURRENT_SOURCE_DIR}/GSL.natvis
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GSL.natvis>
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,9 @@ find_package(Git)
 include(GNUInstallDirs)
 
 # creates a library GSL which is an interface (header files only)
-add_library(GSL INTERFACE)
+# Target must be renamed to avoid conflics with GNU Scientific Library
+add_library(Microsoft.GSL INTERFACE)
+add_library(GSL ALIAS Microsoft.GSL)
 
 # determine whether this is a standalone project or included by other projects
 set(GSL_STANDALONE_PROJECT OFF)
@@ -24,7 +26,7 @@ if (CMAKE_VERSION VERSION_LESS 3.7.9)
         include(CheckCXXCompilerFlag)
         CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
         if(COMPILER_SUPPORTS_CXX14)
-            target_compile_options(GSL INTERFACE "-std=c++14")
+            target_compile_options(Microsoft.GSL INTERFACE "-std=c++14")
         else()
             message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
         endif()
@@ -32,13 +34,13 @@ if (CMAKE_VERSION VERSION_LESS 3.7.9)
     endif()
 else ()
     # set the GSL library to be compiled only with c++14
-    target_compile_features(GSL INTERFACE cxx_std_14)
+    target_compile_features(Microsoft.GSL INTERFACE cxx_std_14)
     # on *nix systems force the use of -std=c++XX instead of -std=gnu++XX (default)
     set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 # add definitions to the library and targets that consume it
-target_compile_definitions(GSL INTERFACE
+target_compile_definitions(Microsoft.GSL INTERFACE
     $<$<CXX_COMPILER_ID:MSVC>:
         # remove unnecessary warnings about unchecked iterators
         _SCL_SECURE_NO_WARNINGS
@@ -46,7 +48,7 @@ target_compile_definitions(GSL INTERFACE
 )
 
 # add include folders to the library and targets that consume it
-target_include_directories(GSL INTERFACE
+target_include_directories(Microsoft.GSL INTERFACE
     $<BUILD_INTERFACE:
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     >
@@ -61,12 +63,12 @@ endif()
 
 # add natvis file to the library so it will automatically be loaded into Visual Studio
 if(VS_ADD_NATIVE_VISUALIZERS)
-    target_sources(GSL INTERFACE
+  target_sources(Microsoft.GSL INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/GSL.natvis
     )
 endif()
 
-install(TARGETS GSL EXPORT GSLConfig
+install(TARGETS Microsoft.GSL EXPORT Microsoft.GSLConfig
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -76,8 +78,9 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 # Make library importable by other projects
-install(EXPORT GSLConfig DESTINATION share/GSL/cmake)
-export(TARGETS GSL FILE GSLConfig.cmake)
+install(EXPORT Microsoft.GSLConfig DESTINATION share/GSL/cmake)
+export(TARGETS Microsoft.GSL FILE Microsoft.GSLConfig.cmake)
+
 
 option(GSL_TEST "Generate tests." ${GSL_STANDALONE_PROJECT})
 if (GSL_TEST)


### PR DESCRIPTION
Currently no GSLConfig.cmake file was installed so find_package could not be used with GSL.
Fixed CMakeLists.txt to install GSLConfig.cmake so that find_package can be used.

See https://github.com/Microsoft/GSL/pull/708